### PR TITLE
msm.counts_to_probs interface

### DIFF
--- a/stag/msm/__init__.py
+++ b/stag/msm/__init__.py
@@ -4,4 +4,4 @@ from __future__ import print_function, division, absolute_import
 from .synthetic_data import synthetic_trajectory, synthetic_ensemble
 from .timescales import implied_timescales
 from .transition_matrices import assigns_to_counts, counts_to_probs, \
-    eigenspectra, eq_probs
+    eigenspectra, eq_probs, transpose

--- a/stag/msm/test_msm.py
+++ b/stag/msm/test_msm.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy.sparse
 
 from .transition_matrices import counts_to_probs, assigns_to_counts, \
-    eigenspectra
+    eigenspectra, transpose
 from .timescales import implied_timescales
 
 
@@ -25,7 +25,8 @@ def test_implied_timescales():
           ([0]*10 + [1]*30 + [2]*20),
           ])
 
-    tscales = implied_timescales(in_assigns, lag_times=range(1, 5))
+    tscales = implied_timescales(in_assigns, lag_times=range(1, 5),
+                                 symmetrization=None)
     expected = np.array(
         [[1., 26.029585],
          [2., 24.852135],
@@ -35,7 +36,7 @@ def test_implied_timescales():
     assert_allclose(tscales, expected, rtol=1e-03)
 
     tscales = implied_timescales(
-        in_assigns, lag_times=range(1, 5), symmetrization='transpose')
+        in_assigns, lag_times=range(1, 5), symmetrization=transpose)
     expected = np.array(
         [[1., 38.497835],
          [2., 36.990989],
@@ -96,15 +97,10 @@ def test_counts_to_probs_symm_options():
          [4, 2, 4],
          [7, 3, 0]])
 
-    with assert_raises(NotImplementedError):
-        counts = counts_to_probs(in_m, 'mle')
-    with assert_raises(NotImplementedError):
-        counts = counts_to_probs(in_m, 'some_garbage_value')
-
-    counts = counts_to_probs(in_m, 'TranSPOSE')
-    assert_allclose(counts, np.array([[ 0.      ,  0.285714,  0.714286],
-                                      [ 0.352941,  0.235294,  0.411765],
-                                      [ 0.681818,  0.318182,  0.      ]]),
+    counts = counts_to_probs(in_m, transpose)
+    assert_allclose(counts, np.array([[0.      ,  0.285714,  0.714286],
+                                      [0.352941,  0.235294,  0.411765],
+                                      [0.681818,  0.318182,  0.      ]]),
                     rtol=1e-03)
 
     counts = counts_to_probs(in_m, None)

--- a/stag/msm/timescales.py
+++ b/stag/msm/timescales.py
@@ -6,17 +6,21 @@
 # Proprietary and confidential
 
 from __future__ import print_function, division, absolute_import
+import logging
 
 import numpy as np
 
 from .transition_matrices import counts_to_probs, assigns_to_counts, \
-    eigenspectra
+    eigenspectra, transpose
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 def implied_timescales(
         assigns, lag_times, n_imp_times=None,
         sliding_window=True, trim=False,
-        symmetrization=None, n_procs=1):
+        symmetrization=transpose, n_procs=None):
     """Calculate the implied timescales across a range of lag times.
 
     Parameters
@@ -47,6 +51,10 @@ def implied_timescales(
     all_imp_times :  array, shape=(n_states, n_states)
         A transition count matrix.
     """
+
+    if n_procs is not None:
+        logger.warning(
+            "implied_timescales n_procs is currently unimplemented")
 
     # n_imp_times=None -> 10% number of states
     n_states = assigns.max() + 1


### PR DESCRIPTION
- Adds a new test for counts to probs, 
- Makes the `symmetrization` option case-insensitive.

From a design perspective, I don't super love the use of a string, though. Maybe we should replace it with a function? That way you can call:

```python
counts_to_probs(C, msm.transpose)

... elsewhere ...

def transpose(C):
    return C + C.T
```

instead of

```python
counts_to_probs(C, "transpose")
```

The advantages would be 1) no string parsing, 2) more flexibility (you can transpose however you want without changing `counts_to_probs`.