### PR TITLE
File slicing to implied_timescales

### DIFF
--- a/enspara/apps/implied_timescales.py
+++ b/enspara/apps/implied_timescales.py
@@ -24,7 +24,7 @@ def process_command_line(argv):
         "--assignments", required=True,
         help="File containing assignments to states.")
     parser.add_argument(
-        "--n-eigenvalues", default=5,
+        "--n-eigenvalues", default=5, type=int,
         help="Number of eigenvalues to compute for each lag time.")
     parser.add_argument(
         "--lag-times",  default="5:100:2",
@@ -34,6 +34,11 @@ def process_command_line(argv):
         "--symmetrization", default="transpose",
         help="The method to use to enforce detailed balance in the"
              "counts matrix.")
+    parser.add_argument(
+        "--trj-ids", default=None,
+        help="Computed the implied timescales for only the given "
+             "trajectory ids. This is useful for handling assignments "
+             "for shared state space clusterings.")
     parser.add_argument(
         "--processes", default=cpu_count(), type=int,
         help="Number of cores to use.")
@@ -46,6 +51,10 @@ def process_command_line(argv):
     args = parser.parse_args(argv[1:])
 
     args.lag_times = range(*map(int, args.lag_times.split(':')))
+
+    if args.trj_ids is not None:
+        args.trj_ids = slice(*map(int, args.trj_ids.split(':')))
+
     args.symmetrization = getattr(builders, args.symmetrization)
 
     return args
@@ -57,6 +66,10 @@ def main(argv=None):
     args = process_command_line(argv)
 
     assignments = io.loadh(args.assignments)['arr_0']
+    if args.trj_ids is not None:
+        assignments = assignments[args.trj_ids]
+
+    print(args.trj_ids)
 
     tscales = implied_timescales(
         assignments, args.lag_times, n_times=args.n_eigenvalues,


### PR DESCRIPTION
Adds the flag `--trj-ids` to select specific trajectories from the serialized assignments. Useful for making separate implied timescales figures from assignments.