### PR TITLE
rmsd_cluster hack_rmsd performace

### DIFF
--- a/enspara/apps/rmsd_cluster.py
+++ b/enspara/apps/rmsd_cluster.py
@@ -77,6 +77,29 @@ def process_command_line(argv):
 
 
 def rmsd_hack(trj, ref, partitions=None, **kwargs):
+    '''Compute rmsd between trj and ref.
+
+    Accepts all parameters accepted by md.rmsd (not all present below),
+    but can batch the call into separate subcalls using `partitions`.
+    The primary purpose here is to avoid the segmentation fault that can
+    occur when computing rmsds over very large data sets.
+
+    Parameters
+    ----------
+    trj : md.Trajectory
+        For each conformation in this trajectory, compute the RMSD to
+        a particular 'reference' conformation in another trajectory
+        object.
+    ref : md.Trajectory
+        The object containing the reference conformation to measure distances
+        to.
+    partitions : int, default=None
+        The number of times to batch the call to `md.rmsd`.
+
+    See Also
+    --------
+    MDTraj's md.rmsd.
+    '''
 
     if partitions is None or partitions == 1:
         # this call is substantially faster because there is no serial


### PR DESCRIPTION
When `rmsd_hack`'s partition parameter is `1`, `rmsd_cluster` should not incur the performance costs of partitioning. This PR adds a check for that.

In my test case, this gives a 3x speed up.

(Props to @mizimmer90 for catching the low CPU utilization of production runs!)