### PR TITLE
NotImplemented for RaggedArray operations

### DIFF
--- a/enspara/util/array.py
+++ b/enspara/util/array.py
@@ -640,12 +640,10 @@ class RaggedArray(object):
         new_data = getattr(self._data, operator)(other)
 
         if new_data is NotImplemented:
-            raise NotImplementedError(
-                "Operation not understood: %s.%s on value "
-                "%s (type %s)." % (type(self), operator, other, type(other)))
-
-        return RaggedArray(
-            array=new_data, lengths=self.lengths, error_checking=False)
+            return NotImplemented
+        else:
+            return RaggedArray(array=new_data, lengths=self.lengths,
+                               error_checking=False)
 
     # Non-built in functions
     def all(self):

--- a/enspara/util/test_util.py
+++ b/enspara/util/test_util.py
@@ -339,7 +339,7 @@ class Test_RaggedArray(unittest.TestCase):
         a = ra.RaggedArray([[True, False, True, False],
                 [False, True, False]])
 
-        with assert_raises(NotImplementedError):
+        with assert_raises(TypeError):
             a > 'asdfasdfasd'
 
 


### PR DESCRIPTION
RaggedArray now propagates `NotImplemented` when unimplemented operations are attempted (rather than failing abstrusely).