### PR TITLE
Update to Shannon Entropy

### DIFF
--- a/enspara/info_theory/entropy.py
+++ b/enspara/info_theory/entropy.py
@@ -168,7 +168,24 @@ def energy_to_probability(u, kT=2.479):
     return p
 
 
-def shannon_entropy(p):
+def shannon_entropy(p, normalize=True):
+    """Compute the Shannon entropy of a distribution.
+
+    Parameters
+    ----------
+    p : ndarray, (shape=(n_states,))
+        Vector of probabilities representing the distribution over which
+        to calculate the entropy.
+
+    Returns
+    -------
+    H : float
+        The Shannon entropy of the distribution
+    """
+
+    if normalize:
+        p = np.copy(p) / np.sum(p)
+
     inds = np.where(p > 0)[0]
     H = -p[inds].dot(np.log(p[inds]))
     return H


### PR DESCRIPTION
`info_theory.shannon_entropy` now has a docstring and has a `normalize` flag that will normalize counts to a probability.