### PR TITLE
Fixing Tests

### DIFF
--- a/enspara/info_theory/entropy.py
+++ b/enspara/info_theory/entropy.py
@@ -26,7 +26,7 @@ def Q_from_assignments(
 
     # get counts matrix
     Q_counts = assigns_to_counts(
-        assignments, n_states=n_states, lag_time=lag_time)
+        assignments, max_n_states=n_states, lag_time=lag_time)
 
     # add prior counts
     Q_counts = np.array(Q_counts.todense()) + prior_counts


### PR DESCRIPTION
The change from `n_states` to `max_n_states` in `assigns_to_counts` broke a few of our `info_theory` tests. This PR fixes them.