### PR TITLE
1d assignments in assigns_to_counts.

### DIFF
--- a/enspara/msm/transition_matrices.py
+++ b/enspara/msm/transition_matrices.py
@@ -16,6 +16,7 @@ import scipy.sparse
 import scipy.sparse.linalg
 from scipy.sparse.csgraph import connected_components
 
+from .. import exception
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -136,7 +137,11 @@ def assigns_to_counts(
 
     # if it's 1d, later stuff will fail
     if len(assigns.shape) == 1:
-        assigns = assigns.reshape(1, -1)
+        raise exception.DataInvalid(
+            'The given assignments array has 1-dimensional shape %s. '
+            'Two dimensional shapes = (n_trj, n_frames) are expected. '
+            'If this is really what you want, try using '
+            'assignments.reshape(1, -1) to create a single-row 2d array.')
 
     assigns = np.array([a[np.where(a != -1)] for a in assigns])
 

--- a/enspara/test/test_msm_funcs.py
+++ b/enspara/test/test_msm_funcs.py
@@ -1,11 +1,13 @@
 import tempfile
 import warnings
 
-from nose.tools import assert_equal, assert_is
+from nose.tools import assert_equal, assert_is, raises
 from numpy.testing import assert_array_equal, assert_allclose
 
 import numpy as np
 import scipy.sparse
+
+from .. import exception
 
 from ..msm import builders
 from ..msm.transition_matrices import assigns_to_counts, eigenspectrum, \
@@ -133,6 +135,7 @@ def test_assigns_to_counts_negnums():
     assert_array_equal(counts.toarray(), expected)
 
 
+@raises(exception.DataInvalid)
 def test_assigns_to_counts_1d():
     """assigns_to_counts handles 1d arrays gracefully
     """


### PR DESCRIPTION
Previously, if a 1d array was used in `assigns_to_counts`, we would error out with something very cryptic. This PR introduces a check for this and a much more clear error.