### PR TITLE
Allow single integer in specification of number of states for MI matrix

### DIFF
--- a/enspara/info_theory/mutual_info.py
+++ b/enspara/info_theory/mutual_info.py
@@ -261,8 +261,8 @@ def mi_to_apc(mi_arr):
     return np.matmul(mi_arr, mi_arr) / (len(mi_arr) * len(mi_arr))
 
 
-def mi_matrix(assignments_a, assignments_b, n_states_a, n_states_b,
-              compute_diagonal=True, n_procs=None):
+def mi_matrix(assignments_a, assignments_b, n_states_a,
+              n_states_b, compute_diagonal=True, n_procs=None):
     """Compute the all-to-all matrix of mutual information across
     trajectories of assigned states.
 
@@ -272,10 +272,11 @@ def mi_matrix(assignments_a, assignments_b, n_states_a, n_states_b,
         Array of assigned/binned features
     assignments_b : array-like, shape=(n_trajectories, n_frames, n_features)
         Array of assigned/binned features
-    n_states_a : array, shape(n_features_a,)
-        Number of possible states for each feature in `states_a`
-    n_states_b : array, shape=(n_features_b,)
-        Number of possible states for each feature in `states_b`
+    n_states_a : int or array, shape(n_features_a,)
+        Number of possible states for each feature in `states_a`. If an
+        integer is given, it is assumed to apply to all features.
+    n_states_b : int or array, shape=(n_features_b,)
+        As `n_states_a`, but for `assignments_b`
     compute_diagonal: bool, default=True
         Compute the diagonal of the MI matrix, which is the Shannon
         entropy of the univariate distribution (i.e. the feature
@@ -300,6 +301,11 @@ def mi_matrix(assignments_a, assignments_b, n_states_a, n_states_b,
     assignments_a = _end_to_end_concat(assignments_a)
     sa_a = _make_shared_array(assignments_a, c_dtype)
     logger.debug("Allocated shared-memory array of size %s", len(sa_a))
+
+    if not hasattr(n_states_a, '__len__'):
+        n_states_a = [n_states_a] * n_features
+    if not hasattr(n_states_b, '__len__'):
+        n_states_b = [n_states_b] * n_features
 
     if assignments_a is not assignments_b:
         assignments_b = _end_to_end_concat(assignments_b)

--- a/enspara/test/test_mutual_info.py
+++ b/enspara/test/test_mutual_info.py
@@ -149,6 +149,25 @@ def test_symmetrical_mi_nonzero():
         assert_allclose(mi, 0, atol=1e-3)
 
 
+def test_symmetrical_mi_nonzero_int_shape_spec():
+    # test that when we use an integer (rather than a list of integers)
+    # that we correctly assume that the integer is just repeated for all
+    # of the various features.
+
+    nonzero_mi_funcs = [nonzero_mi_np, nonzero_mi_ra, nonzero_mi_list]
+    for a, n_states in (f() for f in nonzero_mi_funcs):
+
+        mi = mutual_info.mi_matrix(a, a, 5, 5)
+
+        assert_almost_equal(mi[-1, -2], 0.86114, decimal=3)
+        mi[-1, -2] = mi[-2, -1] = 0
+
+        assert_almost_equal(np.diag(mi), 1.722, decimal=2)
+        mi[np.diag_indices_from(mi)] = 0
+
+        assert_allclose(mi, 0, atol=1e-3)
+
+
 def test_asymmetrical_mi_nonzero():
     # test that the MI matrix for sets of uncorrelated things results
     # in zero MI, but on asymmetrical data, i.e. a[i] != b[i]


### PR DESCRIPTION
Previously, `mi_matrix` required a specification of the number of possible states for all features individually. It's quite common for it to be the same across all features. This allows the specification of a single integer instead.