### PR TITLE
reassign.py default memory usage

### DIFF
--- a/enspara/apps/reassign.py
+++ b/enspara/apps/reassign.py
@@ -288,7 +288,9 @@ def main(argv=None):
     tick = time.perf_counter()
 
     with open(args.centers, 'rb') as f:
-        centers = concatenate_trjs(pickle.load(f), args.atoms, args.n_procs)
+        centers = concatenate_trjs(
+            pickle.load(f), args.atoms,
+            enspara.util.parallel.auto_nprocs())
     logger.info('Loaded %s centers with %s atoms using selection "%s" '
                 'in %.1f seconds.',
                 len(centers), centers.n_atoms, args.atoms,


### PR DESCRIPTION
Fixes #112.

- Additional documentation for `reassign.py`
- Reduce memory threshold in `reassign.py` to 50%, since the program typically requires more overhead than the previous 90%.
- Remove `--n-procs` and cause it to be controlled by `$OMP_NUM_THREADS` via `enspara.parallel.auto_nprocs`.