### PR TITLE
Implement normalize w/psuedocounts in implied_timescales.py

### DIFF
--- a/enspara/test/test_implied_timescales.py
+++ b/enspara/test/test_implied_timescales.py
@@ -1,8 +1,11 @@
 import os
 
+import numpy as np
+
 from mdtraj.testing import get_fn
 
 from nose.tools import assert_raises, assert_equals
+from numpy.testing import assert_array_equal
 
 from .. import exception
 from ..apps import implied_timescales
@@ -41,3 +44,20 @@ def test_process_units():
     assert_equals(
         implied_timescales.process_units(infer_timestep=get_fn('frame0.xtc')),
         (1000, 'ns'))
+
+
+def test_prior_counts():
+
+    from enspara.msm.builders import normalize
+
+    C = np.array([[7, 1, 3, 1],
+                  [1, 8, 3, 1],
+                  [0, 7, 9, 2],
+                  [0, 2, 3, 4]])
+
+    C_a, T_a, eq_a = implied_timescales.prior_counts(C)
+    C_b, T_b, eq_b = normalize(C, prior_counts=1/len(C))
+
+    assert_array_equal(C_a, C_b)
+    assert_array_equal(T_a, T_b)
+    assert_array_equal(eq_a, eq_b)


### PR DESCRIPTION
- Implements builder `row_normalize` with `prior_counts=1/len(C)` in `implied_timescales.py`
- Implements use of `enspara.util.parallel.auto_nprocs` in `implied_timescales.py`