### PR TITLE
Fix error when specifying a prior counts matrix.

### DIFF
--- a/enspara/msm/builders.py
+++ b/enspara/msm/builders.py
@@ -207,6 +207,7 @@ def _row_normalize(C):
         T = inv_weights.dot(C_csr)
         T = type(C)(T)  # recast T to the input type
     else:
+        C = np.array(C)
         weights = np.asarray(C.sum(axis=1)).flatten()
         inv_weights = np.zeros(n_states)
         inv_weights[weights > 0] = 1.0 / weights[weights > 0]

--- a/enspara/test/test_msm_funcs.py
+++ b/enspara/test/test_msm_funcs.py
@@ -346,4 +346,3 @@ def test_prior_counts():
     calculated_counts, _, _ = builders.normalize(
         sparse_counts, prior_counts=prior, calculate_eq_probs=False)
     assert_array_equal(calculated_counts, expected_counts)
-


### PR DESCRIPTION
When using `builders.normalize` with the `prior_counts` parameter, it was previously caused an error if the input was an array or matrix, because of some typing rules.