### PR TITLE
Make lag_time parameter mandatory in assigns_to_counts

### DIFF
--- a/enspara/msm/transition_matrices.py
+++ b/enspara/msm/transition_matrices.py
@@ -9,6 +9,7 @@ from __future__ import print_function, division, absolute_import
 
 import logging
 import csv
+import numbers
 
 import numpy as np
 import scipy
@@ -110,7 +111,7 @@ class TrimMapping:
 
 
 def assigns_to_counts(
-        assigns, max_n_states=None, lag_time=1, sliding_window=True):
+        assigns, lag_time, max_n_states=None, sliding_window=True):
     """Count transitions between states in a single trajectory.
 
     Parameters
@@ -118,13 +119,13 @@ def assigns_to_counts(
     assigns : array, shape=(traj_len, )
         A 2-D array where each row is a trajectory consisting of a
         sequence of state indices.
+    lag_time : int
+        The lag time (i.e. observation interval) for counting
+        transitions.
     max_n_states : int, default=None
         The number of states. This is useful for controlling the
         dimensions of the transition count matrix in cases where the
         input trajectory does not necessarily visit every state.
-    lag_time : int, default=1
-        The lag time (i.e. observation interval) for counting
-        transitions.
     sliding_window : bool, default=True
         Whether to use a sliding window for counting transitions or to
         take every lag_time'th state.
@@ -134,6 +135,15 @@ def assigns_to_counts(
     C :  array, shape=(n_states, n_states)
         A transition count matrix.
     """
+
+    if not isinstance(lag_time, numbers.Integral):
+        raise exception.DataInvalid(
+            "The lag time must be an integer. Got %s type %s." %
+            lag_time, type(lag_time))
+    if lag_time < 1:
+        raise exception.DataInvalid(
+            "Lag times must be be strictly greater than 0. Got '%s'." %
+            lag_time)
 
     # if it's 1d, later stuff will fail
     if len(assigns.shape) == 1:

--- a/enspara/test/test_msm_funcs.py
+++ b/enspara/test/test_msm_funcs.py
@@ -127,7 +127,7 @@ def test_assigns_to_counts_negnums():
              [1, 2, -1, -1],
              [1, 0,  0, 1]])
 
-    counts = assigns_to_counts(in_m)
+    counts = assigns_to_counts(in_m, lag_time=1)
 
     expected = np.array([[1, 1, 1],
                          [1, 0, 1],
@@ -146,7 +146,7 @@ def test_assigns_to_counts_1d():
              [1, 2, -1, -1],
              [1, 0,  0, 1]]).flatten()
 
-    counts = assigns_to_counts(in_m)
+    counts = assigns_to_counts(in_m, lag_time=1)
 
     expected = np.array([[1, 2, 1],
                          [1, 0, 1],


### PR DESCRIPTION
- [x] make `lag_time` parameter of `assigns_to_counts` mandatory (since it is a scientific decision)
- [x] add additional sanity checking to `assigns_to_counts`; integers, etc.