### PR TITLE
Protect mutual_information function from zero observations

### DIFF
--- a/enspara/info_theory/mutual_info.py
+++ b/enspara/info_theory/mutual_info.py
@@ -258,16 +258,27 @@ def mutual_information(jc):
 
     jc = _validate_joint_counts_matrix(jc)
 
-    # sum across all possibilities
+    # marginalize both state axes as number of observations along 'a'
+    # and 'b' dimensions
     n_obs_a_i = jc.sum(axis=-1)
     n_obs_b_i = jc.sum(axis=-2)
 
-    P_a = n_obs_a_i / n_obs_a_i.sum(axis=-1)[..., None]
-    P_b = n_obs_b_i / n_obs_b_i.sum(axis=-1)[..., None]
-
+    # marginalize other axis to get total number of observations for
+    # each feature
     n_obs = n_obs_a_i.sum(axis=-1)
-    P_a_b = jc / n_obs[..., None, None]
 
+    P_a = np.divide(n_obs_a_i, n_obs[..., None],
+                    where=n_obs[..., None] > 0)
+    P_b = np.divide(n_obs_b_i, n_obs[..., None],
+                    where=n_obs[..., None] > 0)
+
+    assert np.all(~np.isnan(P_a))
+    assert np.all(~np.isnan(P_b))
+
+    P_a_b = np.divide(jc, n_obs[..., None, None],
+                      where=n_obs[..., None, None] > 0)
+
+    assert np.all(~np.isnan(P_a_b))
     mi = np.zeros(shape=jc.shape[0:2])
     for i in range(jc.shape[0]):
         for j in range(jc.shape[1]):


### PR DESCRIPTION
Protect `info_theory.mutual_information(jc)` from zero-counts in certain cells.