### PR TITLE
Elaborate SharedArray OOM error

### DIFF
--- a/enspara/test/test_mutual_info.py
+++ b/enspara/test/test_mutual_info.py
@@ -11,6 +11,8 @@ from enspara import exception
 from enspara.util import array as ra
 from enspara.info_theory import mutual_info
 
+from . import fix_np_rng
+
 
 # GENERATORS FOR BUILDING ARRAYS
 
@@ -131,6 +133,7 @@ def test_asymmetrical_mi_zero():
         assert_allclose(mi, 0, atol=1e-3)
 
 
+@fix_np_rng(0)
 def test_symmetrical_mi_nonzero():
     # test that the MI matrix for sets of uncorrelated things results
     # in zero MI

--- a/enspara/test/test_mutual_info.py
+++ b/enspara/test/test_mutual_info.py
@@ -11,7 +11,7 @@ from enspara import exception
 from enspara.util import array as ra
 from enspara.info_theory import mutual_info
 
-from . import fix_np_rng
+from .util import fix_np_rng
 
 
 # GENERATORS FOR BUILDING ARRAYS

--- a/enspara/util/load.py
+++ b/enspara/util/load.py
@@ -228,9 +228,10 @@ def shared_array_like_trj(lengths, example_trj):
             raise
         arr_bytes = reduce(mul, full_shape, 1) * ctypes.sizeof(dtype)
         raise exception.InsufficientResourceError(
-            ("Couldn't allocate array of size %.2f GB on %s as part of "
+            ("Couldn't allocate array of size %.2f GB to %s as part of "
              "loading trajectories in parallel. Check this partition "
-             "to ensure it has sufficient space.") %
+             "to ensure it has sufficient space or set $TEMPDIR to a "
+             "path that does have sufficient space.") %
             (os.path.basename(mp.util.get_temp_dir()),
              arr_bytes / 1024**3))
 

--- a/enspara/util/load.py
+++ b/enspara/util/load.py
@@ -230,8 +230,9 @@ def shared_array_like_trj(lengths, example_trj):
         raise exception.InsufficientResourceError(
             ("Couldn't allocate array of size %.2f GB to %s as part of "
              "loading trajectories in parallel. Check this partition "
-             "to ensure it has sufficient space or set $TEMPDIR to a "
-             "path that does have sufficient space.") %
+             "to ensure it has sufficient space or set $TMPDIR to a "
+             "path that does have sufficient space. (See the tempfile "
+             "module documentation on this behavior.)") %
             (os.path.basename(mp.util.get_temp_dir()),
              arr_bytes / 1024**3))
 

--- a/enspara/util/load.py
+++ b/enspara/util/load.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import math
 
@@ -227,9 +228,11 @@ def shared_array_like_trj(lengths, example_trj):
             raise
         arr_bytes = reduce(mul, full_shape, 1) * ctypes.sizeof(dtype)
         raise exception.InsufficientResourceError(
-            ("Couldn't allocate array of size %.2f GB. Run df -h to "
-             "ensure that shared memory (/tmp/shm or similar) can "
-             "accommodate an array of this size.") % (arr_bytes / 1024**3))
+            ("Couldn't allocate array of size %.2f GB on %s as part of "
+             "loading trajectories in parallel. Check this partition "
+             "to ensure it has sufficient space.") %
+            (os.path.basename(mp.util.get_temp_dir()),
+             arr_bytes / 1024**3))
 
     return full_shape, shared_array
 


### PR DESCRIPTION
An `InsufficientResourceError` is raised if multiprocessing's `Array` constructor object can't allocate sufficient memory. This PR adds additional information about which directory is relevant.