### PR TITLE
Modify buildbot configuration to fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
             export PATH=$HOME/miniconda3/bin:$PATH
             conda create --name myenv python==$PYTHON_VERSION
             conda activate myenv
+            conda init bash
+            source ~/.bashrc
             conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
             conda install --quiet --yes -c omnia mdtraj
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,9 @@ jobs:
             conda init bash
 
       - run:
-          name: Install numpy, cython, mdtra
+          name: Install numpy, cython, mdtraj
           command: |
+            export PATH=$HOME/miniconda3/bin:$PATH
             conda activate myenv
             conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
             conda install --quiet --yes -c omnia mdtraj

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,11 @@ workflows:
 jobs:
   py3.6-np1.15: &test-template
     docker:
-      - image: circleci/python:3.6.8-stretch
+      - image: circleci/python:stretch
     environment:
       NUMPY_VERSION: 1.15.2
       CYTHON_VERSION: 0.27
+      PYTHON_VERSION: 3.6.8
 
     working_directory: ~/repo
 
@@ -46,6 +47,7 @@ jobs:
           name: Install numpy, cython, mdtraj
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
+            conda install --quiet --yes python==$PYTHON_VERSION
             conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
             conda install --quiet --yes -c omnia mdtraj
 
@@ -94,20 +96,23 @@ jobs:
 
   py3.5-np1.15:
     <<: *test-template
-    docker:
-      - image: circleci/python:3.5.7-stretch
+    environment:
+      NUMPY_VERSION: 1.15.2
+      CYTHON_VERSION: 0.27
+      PYTHON_VERSION: 3.5.7
 
   py3.6-np1.14:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
       CYTHON_VERSION: 0.27
+      PYTHON_VERSION: 3.5.7
 
   py3.5-np1.14:
     <<: *test-template
-    docker:
-      - image: circleci/python:3.5.7-stretch
     environment:
       NUMPY_VERSION: 1.14.2
       CYTHON_VERSION: 0.27
+      PYTHON_VERSION: 3.6.8
+
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - image: circleci/python:3.6.8-stretch
     environment:
       NUMPY_VERSION: 1.15.2
-      CYTHON_VERSION: 0.26
+      CYTHON_VERSION: 0.27
 
     working_directory: ~/repo
 
@@ -101,7 +101,7 @@ jobs:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
-      CYTHON_VERSION: 0.26
+      CYTHON_VERSION: 0.27
 
   py3.5-np1.14:
     <<: *test-template
@@ -109,5 +109,5 @@ jobs:
       - image: circleci/python:3.5.7-stretch
     environment:
       NUMPY_VERSION: 1.14.2
-      CYTHON_VERSION: 0.26
+      CYTHON_VERSION: 0.27
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,9 @@ jobs:
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
             conda create --name myenv python==$PYTHON_VERSION
-            conda activate myenv
             conda init bash
             source ~/.bashrc
+            conda activate myenv
             conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
             conda install --quiet --yes -c omnia mdtraj
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,20 +36,24 @@ jobs:
             - v1-dependencies-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
 
       - run:
-          name: install anaconda
+          name: Install anaconda
           command: |
             wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
             chmod +x ~/miniconda.sh && ~/miniconda.sh -b
             export PATH=$HOME/miniconda3/bin:$PATH
             conda update --quiet --yes conda
+            conda init bash
 
       - run:
-          name: Install numpy, cython, mdtraj
+          name: Create conda environment
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
             conda create --name myenv python==$PYTHON_VERSION
             conda init bash
-            source ~/.bashrc
+
+      - run:
+          name: Install numpy, cython, mdtra
+          command: |
             conda activate myenv
             conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
             conda install --quiet --yes -c omnia mdtraj

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - image: circleci/python:stretch
     environment:
       NUMPY_VERSION: 1.15.2
-      CYTHON_VERSION: 0.26
+      CYTHON_VERSION: 0.26.1
       PYTHON_VERSION: 3.6.8
 
     working_directory: ~/repo
@@ -47,8 +47,9 @@ jobs:
           name: Install numpy, cython, mdtraj
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
-            conda create --name myenv python==$PYTHON_VERSION numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
+            conda create --name myenv python==$PYTHON_VERSION
             conda activate myenv
+            conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
             conda install --quiet --yes -c omnia mdtraj
 
       # - run:
@@ -101,21 +102,21 @@ jobs:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.15.2
-      CYTHON_VERSION: 0.26
+      CYTHON_VERSION: 0.26.1
       PYTHON_VERSION: 3.5.6
 
   py3.6-np1.14:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
-      CYTHON_VERSION: 0.26
+      CYTHON_VERSION: 0.26.1
       PYTHON_VERSION: 3.6.8
 
   py3.5-np1.14:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
-      CYTHON_VERSION: 0.26
+      CYTHON_VERSION: 0.26.1
       PYTHON_VERSION: 3.5.6
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,8 @@ jobs:
           name: Install numpy, cython, mdtraj
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
-            conda install --quiet --yes python==$PYTHON_VERSION
-            conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
+            conda create --name myenv python==$PYTHON_VERSION numpy==$NUMPY_VERSION cython==$CYTHON_VERSION
+            conda activate myenv
             conda install --quiet --yes -c omnia mdtraj
 
       # - run:
@@ -69,6 +69,7 @@ jobs:
           name: Install and build enspara
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
+            conda activate myenv
             pip install --progress-bar off .[dev]
             python setup.py build_ext --inplace
             python setup.py install
@@ -82,12 +83,14 @@ jobs:
           name: Run non-MPI tests
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
+            conda activate myenv
             nosetests -a '!mpi' enspara
 
       - run:
           name: Run MPI tests
           command: |
             export PATH=$HOME/miniconda3/bin:$PATH
+            conda activate myenv
             OMP_NUM_THREADS=1 mpiexec -n 2 nosetests -a mpi enspara
 
       - store_artifacts:
@@ -99,20 +102,20 @@ jobs:
     environment:
       NUMPY_VERSION: 1.15.2
       CYTHON_VERSION: 0.26
-      PYTHON_VERSION: 3.5.7
+      PYTHON_VERSION: 3.5.6
 
   py3.6-np1.14:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
       CYTHON_VERSION: 0.26
-      PYTHON_VERSION: 3.5.7
+      PYTHON_VERSION: 3.6.8
 
   py3.5-np1.14:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
       CYTHON_VERSION: 0.26
-      PYTHON_VERSION: 3.6.8
+      PYTHON_VERSION: 3.5.6
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ jobs:
       - run:
           name: Install numpy, cython, mdtraj
           command: |
+            source /home/circleci/.bashrc
             export PATH=$HOME/miniconda3/bin:$PATH
             conda activate myenv
             conda install --quiet --yes numpy==$NUMPY_VERSION cython==$CYTHON_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - image: circleci/python:stretch
     environment:
       NUMPY_VERSION: 1.15.2
-      CYTHON_VERSION: 0.27
+      CYTHON_VERSION: 0.26
       PYTHON_VERSION: 3.6.8
 
     working_directory: ~/repo
@@ -98,21 +98,21 @@ jobs:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.15.2
-      CYTHON_VERSION: 0.27
+      CYTHON_VERSION: 0.26
       PYTHON_VERSION: 3.5.7
 
   py3.6-np1.14:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
-      CYTHON_VERSION: 0.27
+      CYTHON_VERSION: 0.26
       PYTHON_VERSION: 3.5.7
 
   py3.5-np1.14:
     <<: *test-template
     environment:
       NUMPY_VERSION: 1.14.2
-      CYTHON_VERSION: 0.27
+      CYTHON_VERSION: 0.26
       PYTHON_VERSION: 3.6.8
 
 


### PR DESCRIPTION
The build appears to be failing since anaconda can no longer figure out how to install cython. Reasons unclear.