### PR TITLE
Update pocket-detection.rst

### DIFF
--- a/docs/source/pocket-detection.rst
+++ b/docs/source/pocket-detection.rst
@@ -21,7 +21,7 @@ Finding pockets with LIGSITE
     pdb = md.load('reagents/m182t-a243-exposon-open.pdb')
 
     # run ligsite
-    pockets_xyz = enspara.geometry.get_pocket_cells(struct=pdb)
+    pockets_xyz = enspara.geometry.pockets.get_pocket_cells(struct=pdb)
 
     # build a pdb of hydrogen atoms for each grid point so it can be
     # examined in a visualization program (e.g. pymol)


### PR DESCRIPTION
added in the .pockets module, which must have been added after this example was written. Without it

    pockets_xyz = enspara.geometry.get_pocket_cells(struct=pdb)

Throws an exception