### PR TITLE
Fixed obsolteted import of 'Iterable' from collections.

### DIFF
--- a/enspara/ra/ra.py
+++ b/enspara/ra/ra.py
@@ -371,7 +371,7 @@ def partition_list(list_to_partition, partition_lengths):
 def _is_iterable(iterable):
     """Indicates if the input is iterable but not due to being a string or
        bytes. Returns a boolean value."""
-    iterable_bool = isinstance(iterable, collections.Iterable) and not \
+    iterable_bool = isinstance(iterable, collections.abc.Iterable) and not \
         isinstance(iterable, (str, bytes))
     return iterable_bool
 


### PR DESCRIPTION
Added four characters `RaggedArray` uses to check if the input sequence used by the RaggedArray constructor is in fact iterable. Abstract Base Classes were moved into the `abc` submodule of `collections` in python 3.3, but these (in our case the relevant one is `Iterable`) were visible at the top-level collections module for a few subsequent versions for backwards compatibility. I don't know when they changed the warning to an error, but in 3.10 it certainly is.

This changes the import so it'll be consistent and correct for all modern python3s, going back to 3.2 (which is deeply unsupported and enspara wouldn't work with anyway for other reasons). Seems like an open and shut case.