### PR TITLE
Subsample features

### DIFF
--- a/enspara/apps/cluster.py
+++ b/enspara/apps/cluster.py
@@ -182,10 +182,6 @@ def process_command_line(argv):
                 "The given distance (%s) is not compatible with features." %
                 args.cluster_distance)
 
-        if args.subsample != 1 and len(args.features) == 1:
-                raise exception.ImproperlyConfigured(
-                    "Subsampling is not supported for h5 inputs.")
-
         # TODO: not necessary if mutually exclusvie above works
         if args.trajectories:
             raise exception.ImproperlyConfigured(
@@ -333,8 +329,8 @@ def main(argv=None):
     del data
 
     logger.info(
-        "Clustered %s frames into %s clusters in %s seconds.",
-        sum(lengths), len(clustering.centers_), clustering.runtime_)
+        f"Clustered {sum(lengths)} frames into {len(clustering.centers_)} " 
+        f"clusters in {clustering.runtime_} seconds.")
 
     result = clustering.result_
     if mpi_mode:

--- a/enspara/mpi/io.py
+++ b/enspara/mpi/io.py
@@ -52,7 +52,7 @@ def load_h5_as_striped(filename, stride=1):
                                     root=0)
 
     #This is hacky way to get proper lengths with stride > 1, better way?
-    if stride!=1:
+    if stride != 1:
         global_lengths = [1+np.floor(s[0]/stride).astype('int') for s in all_shapes]
     else:
         global_lengths = [s[0] for s in all_shapes]

--- a/enspara/mpi/io.py
+++ b/enspara/mpi/io.py
@@ -50,8 +50,10 @@ def load_h5_as_striped(filename, stride=1):
                                   root=0)
         all_shapes = mpi.comm.bcast(all_shapes if mpi.rank() == 0 else None,
                                     root=0)
-    global_lengths = [s[0] for s in all_shapes]
 
+    #This is hacky way to get proper lengths with stride > 1, better way?
+    global_lengths = [1+np.floor(s[0]/stride).astype('int') for s in all_shapes]
+    print(global_lengths)
     if len(all_keys) == 2 and 'array' in all_keys and 'lengths' in all_keys:
         raise NotImplementedError(
             'Parallel loading of RaggedArrays that have been stored as '

--- a/enspara/mpi/io.py
+++ b/enspara/mpi/io.py
@@ -52,7 +52,10 @@ def load_h5_as_striped(filename, stride=1):
                                     root=0)
 
     #This is hacky way to get proper lengths with stride > 1, better way?
-    global_lengths = [1+np.floor(s[0]/stride).astype('int') for s in all_shapes]
+    if stride!=1:
+        global_lengths = [1+np.floor(s[0]/stride).astype('int') for s in all_shapes]
+    else:
+        global_lengths = [s[0] for s in all_shapes]
     print(global_lengths)
     if len(all_keys) == 2 and 'array' in all_keys and 'lengths' in all_keys:
         raise NotImplementedError(

--- a/enspara/util/load.py
+++ b/enspara/util/load.py
@@ -94,7 +94,7 @@ def load_as_concatenated(filenames, lengths=None, processes=None,
     # configure arguments to md.load
     if kwargs and args:
         raise exception.ImproperlyConfigured(
-            "Additional unnamed args can only be supplied iff no "
+            "Additional unnamed args can only be supplied if no "
             "additonal keyword args are supplied")
     elif kwargs:
         args = [kwargs] * len(filenames)


### PR DESCRIPTION
Fixes #232 by:
- Adding reassignment for features
- Removing code in `cluster.py` preventing passing both subsample and features.
- Changes math around expected array lengths for subsampling features (this was hacky- would appreciate alternate thoughts).

I wonder if it's also worth looking at file handling for features files? I noticed the loader is expecting a h5 file if only one set of features is passed, but a series of numpy files if multiple are passed. @justinrporter do you know why this was preferred? I could try and add some file extension logic as it might be nice to pass multiple h5 files (e.g. multiple ragged datasets), or a single numpy file (single homogenous dataset). Happy to do this as the same or a separate PR.