### PR TITLE
Fix for CARDS angle=360 issue.

### DIFF
--- a/enspara/geometry/rotamer.py
+++ b/enspara/geometry/rotamer.py
@@ -14,7 +14,7 @@ def dihedral_angles(traj, dihedral_type):
     # transform so angles range from 0 to 360 instead of radians or -180 to 180
     angles = np.rad2deg(angles)
     angles[np.where(angles < 0)] += 360
-    angles[np.where(angles > 359.5)] = 359.5
+    angles[np.where(angles == 360)] = 0
 
     n_angles = angles.shape[1]
     ref_atom_inds = np.zeros(n_angles)

--- a/enspara/geometry/rotamer.py
+++ b/enspara/geometry/rotamer.py
@@ -14,7 +14,7 @@ def dihedral_angles(traj, dihedral_type):
     # transform so angles range from 0 to 360 instead of radians or -180 to 180
     angles = np.rad2deg(angles)
     angles[np.where(angles < 0)] += 360
-    angles[np.where(angles == 360)] = 0
+    angles[np.where(angles > 359.5)] = 359.5
 
     n_angles = angles.shape[1]
     ref_atom_inds = np.zeros(n_angles)

--- a/enspara/geometry/rotamer.py
+++ b/enspara/geometry/rotamer.py
@@ -14,6 +14,7 @@ def dihedral_angles(traj, dihedral_type):
     # transform so angles range from 0 to 360 instead of radians or -180 to 180
     angles = np.rad2deg(angles)
     angles[np.where(angles < 0)] += 360
+    angles[np.where(angles > 359.5)] = 359.5
 
     n_angles = angles.shape[1]
     ref_atom_inds = np.zeros(n_angles)


### PR DESCRIPTION
One line patch to guarantee that no frame can return 360.0 degrees for the purposes of CARDS rotamer calculation. When the wrapping frame gets changed in the transformation from -180 to 180 to 0-360 degrees, the 'open' end of the range needs to be redefined to be 360, whereas before it was likely either -180 or 180, and zero, which is the value that becomes 360, is totally permissible. Because of downstream happenings in digitization of values, this creates indexing issues in the bins when numbers incredibly close to zero have 360 added to them, because they get rounded up due to finite floating point precision.

The fix is to set 360 degrees to zero after doing the conversion but before bins are determined. On a test trajectory that bugs out with the previous code this modification works. 