### PR TITLE
Make publish workflow steps all use bash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,15 +38,19 @@ jobs:
         cache-environment: true
         cache-downloads: true
 
-    - run: eval "$(micromamba shell hook --shell=bash)"
+    - name: Add bash hook
+      shell: bash
+      run: eval "$(micromamba shell hook --shell=bash)"
 
     - name: Install package
+      shell: bash
       run: |
         set -eux
         micromamba activate cb-env
         pip install .[dev]
 
     - name: Build (PyPI)
+      shell: bash
       if: ${{ always() }}
       id: pypi-build
       run: |
@@ -55,6 +59,7 @@ jobs:
         python -m build .
 
     - name: Publish (PyPI)
+      shell: bash
       id: pypi-publish
       if: ${{ steps.pypi-build.outcome == 'success' }}
       env:
@@ -66,6 +71,7 @@ jobs:
         twine upload dist/* --verbose --skip-existing
 
     - name: Generate Conda metadata
+      shell: bash
       if: ${{ always() && matrix.os == 'ubuntu-latest' }}
       id: conda-meta
       run: |
@@ -74,6 +80,7 @@ jobs:
         ./gen_meta.py
 
     - name: Build (Conda)
+      shell: bash
       if: ${{ steps.conda-meta.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
       id: conda-build
       run: |
@@ -83,6 +90,7 @@ jobs:
         echo "path=$path" >> $GITHUB_OUTPUT
 
     - name: Publish (Conda)
+      shell: bash
       if: ${{ steps.conda-build.outcome == 'success' && matrix.os == 'ubuntu-latest' }}
       id: conda-publish
       run: |


### PR DESCRIPTION
Apparently conda doesn't like pure sh