### PR TITLE
Bump version number to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "enspara"
-version = "0.2.0"
+version = "0.3.1"
 description = "Tools for ensemble modeling"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
The release was created without the correct version number, so this PR should be merged and a new release (`0.3.1`) should be created.

Will write an SOP for enspara updates in the knowledge base